### PR TITLE
use datetime for accrual and event scheduling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -182,6 +182,31 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+
+[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -206,4 +231,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "38667346873c9f0da70ee3817f66f92964fca0f25663024150e1ac5bc2b6900b"
+content-hash = "0cdb24d093951402fb6622ba4ff7ab43eafcf14f381785b8b4cf3378910fab48"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{ include = "finance_sim", from = "src" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 pytest = "^7.4.2"
+python-dateutil = "^2.8.2"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.7.0"

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from ctypes import ArgumentError
 
 from typing import Callable
 from dataclasses import dataclass
@@ -29,7 +30,7 @@ def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel)
         fieldsInPeriod = nonZeroValuesInDelta(period)
         if fieldsInPeriod == ['months'] or fieldsInPeriod == ['years', 'months']:
             return period.years + period.months / 12
-        raise RuntimeError("Periodic monthly accrual model only supports periods of " +
+        raise ArgumentError("Periodic monthly accrual model only supports periods of " +
                            "containing non-month values")
 
     # pro rata

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -1,107 +1,13 @@
 from __future__ import annotations
-from ctypes import ArgumentError
 
-from typing import Callable
+import sys
+
 from dataclasses import dataclass
 from datetime import date
 from dateutil.relativedelta import relativedelta
-from calendar import isleap
-from enum import Enum
-import sys
-import calendar
+from typing import Callable
 
-class AccrualModel(Enum):
-    ProRata = 0
-    PeriodicMonthly = 1
-    PeriodicSemiMonthly = 2
-    PeriodicWeekly = 3
-    PeriodicBiweekly = 4
-
-def nonZeroValuesInDelta(delta: relativedelta) -> list[str]:
-    result: list[str] = []
-    if delta.years != 0: result.append('years')
-    if delta.months != 0: result.append('months')
-    if delta.days != 0: result.append('days')
-    if delta.leapdays != 0: result.append('leapdays')
-    if delta.hours != 0: result.append('hours')
-    if delta.minutes != 0: result.append('minutes')
-    if delta.seconds != 0: result.append('seconds')
-    if delta.microseconds != 0: result.append('microseconds')
-    return result
-
-def _portionOfYearPeriodicMonthly(date: date, period: relativedelta):
-    fieldsInPeriod = nonZeroValuesInDelta(period)
-    if fieldsInPeriod != ['months'] and fieldsInPeriod != ['years', 'months']:
-        raise ArgumentError("Periodic monthly accrual model does not support periods " +
-                            "containing non-month, non-year values")
-    return period.years + period.months / 12
-
-def _portionOfYearPeriodicSemiMonthly(date: date, period: relativedelta):
-    fieldsInPeriod = nonZeroValuesInDelta
-    daysInMonth = calendar.monthrange(date.year, date.month)[1]
-    dateBeginningPeriod = date - period
-    daysInMonthBeginning = calendar.monthrange(dateBeginningPeriod.year,
-                                               dateBeginningPeriod.month)[1]
-
-    if (
-        fieldsInPeriod != ['days'] and fieldsInPeriod != ['months', 'days'] and \
-        fieldsInPeriod != ['years', 'months', 'days']
-    ):
-        raise ArgumentError("Periodic semi-monthly accrual model does not support " +
-                            "periods containing non-day, non-month, non-year values")
-    if date.day != 15 and date.day != daysInMonth:
-        raise ArgumentError("Periodic semi-monthly accrual model does not support " +
-                            "dates not on the 15th or final day of the month")
-    if dateBeginningPeriod != 15 and dateBeginningPeriod != daysInMonthBeginning:
-        raise ArgumentError("Periodic semi-monthly accrual model requires that the " +
-                            "date that would begin the period be on the 15th or " +
-                            "final day of the month")
-
-    periods = (date.year - dateBeginningPeriod.year) * 24
-    periods += (date.month - dateBeginningPeriod.month) * 2
-    if date.day == daysInMonth and dateBeginningPeriod.day == 15:
-        periods += 1
-    elif date.day == 15 and dateBeginningPeriod.day == daysInMonthBeginning:
-        periods -= 1
-    return periods / 24
-
-def _portionOfYearPeriodicWeekly(date: date, period: relativedelta):
-    fieldsInPeriod = nonZeroValuesInDelta(period)
-    if fieldsInPeriod != ['days']:
-        raise ArgumentError("Periodic weekly accrual model does not support periods " +
-                            "containing non-day values")
-    if period.days % 7:
-        raise ArgumentError("Periodic weekly accrual model only works for periods " +
-                            "that are multiples of 7 days")
-    return (period.days // 7) / 52
-
-def _portionOfYearPeriodicBiweekly(date: date, period: relativedelta):
-    fieldsInPeriod = nonZeroValuesInDelta(period)
-    if fieldsInPeriod != ['days']:
-        raise ArgumentError("Periodic biweekly accrual model does not support " +
-                            "periods containing non-day values")
-    if period.days % 14:
-        raise ArgumentError("Periodic weekly accrual model only works for periods " +
-                            "that are multiples of 14 days")
-    return (period.days // 14) / 26
-
-def _portionOfYearProRata(date: date, period: relativedelta):
-    periodStart = date - period
-    days = date.toordinal() - periodStart.toordinal()
-    daysInYear = 366 if isleap(date.year) else 365
-    return days / daysInYear
-
-def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel) -> float:
-    if accrualModel == AccrualModel.PeriodicMonthly:
-        return _portionOfYearPeriodicMonthly(date, period)
-    elif accrualModel == AccrualModel.PeriodicSemiMonthly:
-        return _portionOfYearPeriodicSemiMonthly(date, period)
-    elif accrualModel == AccrualModel.PeriodicWeekly:
-        return _portionOfYearPeriodicWeekly(date, period)
-    elif accrualModel == AccrualModel.PeriodicBiweekly:
-        return _portionOfYearPeriodicBiweekly(date, period)
-    else: # pro rata
-        return _portionOfYearProRata(date, period)
+from .scheduling import AccrualModel, portionOfYear
 
 class ConstantGrowthAsset(object):
     '''

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -13,9 +13,9 @@ import calendar
 class AccrualModel(Enum):
     ProRata = 0
     PeriodicMonthly = 1
-    PeriodicWeekly = 2
-    PeriodicBiweekly = 3
-    PeriodicSemiMonthly = 4
+    PeriodicSemiMonthly = 2
+    PeriodicWeekly = 3
+    PeriodicBiweekly = 4
 
 def nonZeroValuesInDelta(delta: relativedelta) -> list[str]:
     result: list[str] = []
@@ -36,22 +36,6 @@ def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel)
             raise ArgumentError("Periodic monthly accrual model does not support periods " +
                                 "containing non-month, non-year values")
         return period.years + period.months / 12
-    elif accrualModel == AccrualModel.PeriodicWeekly:
-        if fieldsInPeriod != ['days']:
-            raise ArgumentError("Periodic weekly accrual model does not support periods " +
-                                "containing non-day values")
-        if period.days % 7:
-            raise ArgumentError("Periodic weekly accrual model only works for periods " +
-                                "that are multiples of 7 days")
-        return (period.days // 7) / 52
-    elif accrualModel == AccrualModel.PeriodicBiweekly:
-        if fieldsInPeriod != ['days']:
-            raise ArgumentError("Periodic biweekly accrual model does not support " +
-                                "periods containing non-day values")
-        if period.days % 14:
-            raise ArgumentError("Periodic weekly accrual model only works for periods " +
-                                "that are multiples of 14 days")
-        return (period.days // 14) / 26
     elif accrualModel == AccrualModel.PeriodicSemiMonthly:
         daysInMonth = calendar.monthrange(date.year, date.month)[1]
         if (
@@ -77,6 +61,22 @@ def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel)
         elif date.day == 15 and dateBeginningPeriod.day == daysInMonthBeginning:
             periods -= 1
         return periods / 24
+    elif accrualModel == AccrualModel.PeriodicWeekly:
+        if fieldsInPeriod != ['days']:
+            raise ArgumentError("Periodic weekly accrual model does not support periods " +
+                                "containing non-day values")
+        if period.days % 7:
+            raise ArgumentError("Periodic weekly accrual model only works for periods " +
+                                "that are multiples of 7 days")
+        return (period.days // 7) / 52
+    elif accrualModel == AccrualModel.PeriodicBiweekly:
+        if fieldsInPeriod != ['days']:
+            raise ArgumentError("Periodic biweekly accrual model does not support " +
+                                "periods containing non-day values")
+        if period.days % 14:
+            raise ArgumentError("Periodic weekly accrual model only works for periods " +
+                                "that are multiples of 14 days")
+        return (period.days // 14) / 26
 
     # pro rata
     periodStart = date - period

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -29,60 +29,79 @@ def nonZeroValuesInDelta(delta: relativedelta) -> list[str]:
     if delta.microseconds != 0: result.append('microseconds')
     return result
 
-def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel) -> float:
+def _portionOfYearPeriodicMonthly(date: date, period: relativedelta):
     fieldsInPeriod = nonZeroValuesInDelta(period)
-    if accrualModel == AccrualModel.PeriodicMonthly:
-        if fieldsInPeriod != ['months'] and fieldsInPeriod != ['years', 'months']:
-            raise ArgumentError("Periodic monthly accrual model does not support periods " +
-                                "containing non-month, non-year values")
-        return period.years + period.months / 12
-    elif accrualModel == AccrualModel.PeriodicSemiMonthly:
-        daysInMonth = calendar.monthrange(date.year, date.month)[1]
-        if (
-            fieldsInPeriod != ['days'] and fieldsInPeriod != ['months', 'days'] and \
-            fieldsInPeriod != ['years', 'months', 'days']
-        ):
-            raise ArgumentError("Periodic semi-monthly accrual model does not support " +
-                                "periods containing non-day, non-month, non-year values")
-        if date.day != 15 and date.day != daysInMonth:
-            raise ArgumentError("Periodic semi-monthly accrual model does not support " +
-                                "dates not on the 15th or final day of the month")
-        dateBeginningPeriod = date - period
-        daysInMonthBeginning = calendar.monthrange(dateBeginningPeriod.year,
-                                                   dateBeginningPeriod.month)[1]
-        if dateBeginningPeriod != 15 and dateBeginningPeriod != daysInMonthBeginning:
-            raise ArgumentError("Periodic semi-monthly accrual model requires that the " +
-                                "date that would begin the period be on the 15th or " +
-                                "final day of the month")
-        periods = (date.year - dateBeginningPeriod.year) * 24
-        periods += (date.month - dateBeginningPeriod.month) * 2
-        if date.day == daysInMonth and dateBeginningPeriod.day == 15:
-            periods += 1
-        elif date.day == 15 and dateBeginningPeriod.day == daysInMonthBeginning:
-            periods -= 1
-        return periods / 24
-    elif accrualModel == AccrualModel.PeriodicWeekly:
-        if fieldsInPeriod != ['days']:
-            raise ArgumentError("Periodic weekly accrual model does not support periods " +
-                                "containing non-day values")
-        if period.days % 7:
-            raise ArgumentError("Periodic weekly accrual model only works for periods " +
-                                "that are multiples of 7 days")
-        return (period.days // 7) / 52
-    elif accrualModel == AccrualModel.PeriodicBiweekly:
-        if fieldsInPeriod != ['days']:
-            raise ArgumentError("Periodic biweekly accrual model does not support " +
-                                "periods containing non-day values")
-        if period.days % 14:
-            raise ArgumentError("Periodic weekly accrual model only works for periods " +
-                                "that are multiples of 14 days")
-        return (period.days // 14) / 26
+    if fieldsInPeriod != ['months'] and fieldsInPeriod != ['years', 'months']:
+        raise ArgumentError("Periodic monthly accrual model does not support periods " +
+                            "containing non-month, non-year values")
+    return period.years + period.months / 12
 
-    # pro rata
+def _portionOfYearPeriodicSemiMonthly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta
+    daysInMonth = calendar.monthrange(date.year, date.month)[1]
+    dateBeginningPeriod = date - period
+    daysInMonthBeginning = calendar.monthrange(dateBeginningPeriod.year,
+                                               dateBeginningPeriod.month)[1]
+
+    if (
+        fieldsInPeriod != ['days'] and fieldsInPeriod != ['months', 'days'] and \
+        fieldsInPeriod != ['years', 'months', 'days']
+    ):
+        raise ArgumentError("Periodic semi-monthly accrual model does not support " +
+                            "periods containing non-day, non-month, non-year values")
+    if date.day != 15 and date.day != daysInMonth:
+        raise ArgumentError("Periodic semi-monthly accrual model does not support " +
+                            "dates not on the 15th or final day of the month")
+    if dateBeginningPeriod != 15 and dateBeginningPeriod != daysInMonthBeginning:
+        raise ArgumentError("Periodic semi-monthly accrual model requires that the " +
+                            "date that would begin the period be on the 15th or " +
+                            "final day of the month")
+
+    periods = (date.year - dateBeginningPeriod.year) * 24
+    periods += (date.month - dateBeginningPeriod.month) * 2
+    if date.day == daysInMonth and dateBeginningPeriod.day == 15:
+        periods += 1
+    elif date.day == 15 and dateBeginningPeriod.day == daysInMonthBeginning:
+        periods -= 1
+    return periods / 24
+
+def _portionOfYearPeriodicWeekly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta(period)
+    if fieldsInPeriod != ['days']:
+        raise ArgumentError("Periodic weekly accrual model does not support periods " +
+                            "containing non-day values")
+    if period.days % 7:
+        raise ArgumentError("Periodic weekly accrual model only works for periods " +
+                            "that are multiples of 7 days")
+    return (period.days // 7) / 52
+
+def _portionOfYearPeriodicBiweekly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta(period)
+    if fieldsInPeriod != ['days']:
+        raise ArgumentError("Periodic biweekly accrual model does not support " +
+                            "periods containing non-day values")
+    if period.days % 14:
+        raise ArgumentError("Periodic weekly accrual model only works for periods " +
+                            "that are multiples of 14 days")
+    return (period.days // 14) / 26
+
+def _portionOfYearProRata(date: date, period: relativedelta):
     periodStart = date - period
     days = date.toordinal() - periodStart.toordinal()
     daysInYear = 366 if isleap(date.year) else 365
     return days / daysInYear
+
+def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel) -> float:
+    if accrualModel == AccrualModel.PeriodicMonthly:
+        return _portionOfYearPeriodicMonthly(date, period)
+    elif accrualModel == AccrualModel.PeriodicSemiMonthly:
+        return _portionOfYearPeriodicSemiMonthly(date, period)
+    elif accrualModel == AccrualModel.PeriodicWeekly:
+        return _portionOfYearPeriodicWeekly(date, period)
+    elif accrualModel == AccrualModel.PeriodicBiweekly:
+        return _portionOfYearPeriodicBiweekly(date, period)
+    else: # pro rata
+        return _portionOfYearProRata(date, period)
 
 class ConstantGrowthAsset(object):
     '''

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable
 from dataclasses import dataclass
+from datetime import datetime
 import sys
 
 class ConstantGrowthAsset(object):
@@ -39,8 +40,9 @@ class AmortizingLoan(object):
         
 
 class FinanceState(object):
-    def __init__(self, cash: float = 0):
-        self.cash: float = cash
+    def __init__(self, date: datetime):
+        self.date = date
+        self.cash: float = 0
         self.constantGrowthAssets: list[ConstantGrowthAsset] = []
         self.amortizingLoans: dict[str, AmortizingLoan] = {}
         self.taxableIncome: float = 0
@@ -48,6 +50,7 @@ class FinanceState(object):
 
     def copy(self):
         result = FinanceState()
+        result.date = self.date
         result.cash = self.cash
         result.constantGrowthAssets = self.constantGrowthAssets
         result.amortizingLoans = self.amortizingLoans

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -13,6 +13,7 @@ class AccrualModel(Enum):
     ProRata = 0
     PeriodicMonthly = 1
     PeriodicWeekly = 2
+    PeriodicBiweekly = 3
 
 def nonZeroValuesInDelta(delta: relativedelta) -> list[str]:
     result: list[str] = []
@@ -41,6 +42,14 @@ def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel)
             raise ArgumentError("Periodic weekly accrual model only works for periods " +
                                 "that are multiples of 7 days")
         return (period.days // 7) / 52
+    elif accrualModel == AccrualModel.PeriodicBiweekly:
+        if fieldsInPeriod != ['days']:
+            raise ArgumentError("Periodic biweekly accrual model does not support " +
+                                "periods containing non-day values")
+        if period.days % 14:
+            raise ArgumentError("Periodic weekly accrual model only works for periods " +
+                                "that are multiples of 14 days")
+        return (period.days // 14) / 26
 
     # pro rata
     periodStart = date - period

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 import sys
 
 class ConstantGrowthAsset(object):
@@ -65,10 +65,11 @@ class FinanceHistory(object):
     def setEventComponents(self, events: list[FinanceEvent]):
         self.events = events
 
-    def passEvent(self, idx: int, yearFraction: float):
+    def passEvent(self, date: datetime, period: timedelta):
         newState = self.data[idx - 1].copy()
+        newState.date = date
         for event in self.events:
-            newState = event(self, newState, idx, yearFraction)
+            newState = event(self, newState, date, period)
         self.data.append(newState)
     
     def appendEvent(self, event: FinanceState):
@@ -78,7 +79,7 @@ class FinanceHistory(object):
         return self.data[-1]
 
 
-FinanceEvent = Callable[[FinanceHistory, FinanceState, int, float], FinanceState]
+FinanceEvent = Callable[[FinanceHistory, FinanceState, datetime, timedelta], FinanceState]
 
 
 def constantSalariedIncome(salary: float) -> FinanceEvent:

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -93,7 +93,7 @@ class FinanceHistory(object):
         self.events = events
 
     def passEvent(self, date: date, period: relativedelta):
-        newState = self.data[idx - 1].copy()
+        newState = self.data[-1].copy()
         newState.date = date
         for event in self.events:
             newState = event(self, newState, date, period)

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -163,6 +163,7 @@ class TaxBracket(object):
     income: float
 
 def taxPaymentSchedule(frequency: relativedelta,
+                       accrualModel: AccrualModel,
                        brackets: list[TaxBracket]) -> FinanceEvent:
     if len(brackets) < 1:
         raise RuntimeError('there must be at least one tax bracket')
@@ -179,7 +180,9 @@ def taxPaymentSchedule(frequency: relativedelta,
         if (date - taxPeriod) <= (date - frequency):
             taxDue = 0
             for bracket in brackets[::-1]:
-                adjustedIncomeThreshold = bracket.income * portionOfYear(date, taxPeriod)
+                adjustedIncomeThreshold = bracket.income * portionOfYear(date,
+                                                                         taxPeriod,
+                                                                         accrualModel)
                 if result.taxableIncome > adjustedIncomeThreshold:
                     marginAboveBracket = result.taxableIncome - adjustedIncomeThreshold
                     taxDue += bracket.rate * marginAboveBracket

--- a/src/finance_sim/main.py
+++ b/src/finance_sim/main.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from typing import Callable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import date, timedelta
+from dateutil.relativedelta import relativedelta
 import sys
 
 class ConstantGrowthAsset(object):
@@ -40,7 +41,7 @@ class AmortizingLoan(object):
         
 
 class FinanceState(object):
-    def __init__(self, date: datetime):
+    def __init__(self, date: date = date.today()):
         self.date = date
         self.cash: float = 0
         self.constantGrowthAssets: list[ConstantGrowthAsset] = []
@@ -65,7 +66,7 @@ class FinanceHistory(object):
     def setEventComponents(self, events: list[FinanceEvent]):
         self.events = events
 
-    def passEvent(self, date: datetime, period: timedelta):
+    def passEvent(self, date: date, period: relativedelta):
         newState = self.data[idx - 1].copy()
         newState.date = date
         for event in self.events:
@@ -79,14 +80,14 @@ class FinanceHistory(object):
         return self.data[-1]
 
 
-FinanceEvent = Callable[[FinanceHistory, FinanceState, datetime, timedelta], FinanceState]
+FinanceEvent = Callable[[FinanceHistory, FinanceState, date, relativedelta], FinanceState]
 
 
 def constantSalariedIncome(salary: float) -> FinanceEvent:
     def incomeEvent(history: FinanceHistory,
                     state: FinanceState,
-                    period: int,
-                    yearFraction: float) -> FinanceState:
+                    date: date,
+                    period: relativedelta) -> FinanceState:
         result = state.copy()
         result.cash += salary * yearFraction
         result.taxableIncome += salary * yearFraction

--- a/src/finance_sim/scheduling.py
+++ b/src/finance_sim/scheduling.py
@@ -44,7 +44,7 @@ def _portionOfYearPeriodicSemiMonthly(date: date, period: relativedelta):
     if date.day != 15 and date.day != daysInMonth:
         raise ArgumentError("Periodic semi-monthly accrual model does not support " +
                             "dates not on the 15th or final day of the month")
-    if dateBeginningPeriod != 15 and dateBeginningPeriod != daysInMonthBeginning:
+    if dateBeginningPeriod.day != 15 and dateBeginningPeriod.day != daysInMonthBeginning:
         raise ArgumentError("Periodic semi-monthly accrual model requires that the " +
                             "date that would begin the period be on the 15th or " +
                             "final day of the month")

--- a/src/finance_sim/scheduling.py
+++ b/src/finance_sim/scheduling.py
@@ -26,22 +26,19 @@ def nonZeroValuesInDelta(delta: relativedelta) -> list[str]:
 
 def _portionOfYearPeriodicMonthly(date: date, period: relativedelta):
     fieldsInPeriod = nonZeroValuesInDelta(period)
-    if fieldsInPeriod != ['months'] and fieldsInPeriod != ['years', 'months']:
+    if any([field not in ['months', 'years'] for field in fieldsInPeriod]):
         raise ArgumentError("Periodic monthly accrual model does not support periods " +
                             "containing non-month, non-year values")
     return period.years + period.months / 12
 
 def _portionOfYearPeriodicSemiMonthly(date: date, period: relativedelta):
-    fieldsInPeriod = nonZeroValuesInDelta
+    fieldsInPeriod = nonZeroValuesInDelta(period)
     daysInMonth = monthrange(date.year, date.month)[1]
     dateBeginningPeriod = date - period
     daysInMonthBeginning = monthrange(dateBeginningPeriod.year,
                                       dateBeginningPeriod.month)[1]
 
-    if (
-        fieldsInPeriod != ['days'] and fieldsInPeriod != ['months', 'days'] and \
-        fieldsInPeriod != ['years', 'months', 'days']
-    ):
+    if any([field not in ['days', 'months', 'years'] for field in fieldsInPeriod]):
         raise ArgumentError("Periodic semi-monthly accrual model does not support " +
                             "periods containing non-day, non-month, non-year values")
     if date.day != 15 and date.day != daysInMonth:

--- a/src/finance_sim/scheduling.py
+++ b/src/finance_sim/scheduling.py
@@ -1,0 +1,99 @@
+from calendar import isleap, monthrange
+from ctypes import ArgumentError
+from dateutil.relativedelta import relativedelta
+from datetime import date
+from enum import Enum
+
+class AccrualModel(Enum):
+    ProRata = 0
+    PeriodicMonthly = 1
+    PeriodicSemiMonthly = 2
+    PeriodicWeekly = 3
+    PeriodicBiweekly = 4
+
+def nonZeroValuesInDelta(delta: relativedelta) -> list[str]:
+    result: list[str] = []
+    if delta.years != 0: result.append('years')
+    if delta.months != 0: result.append('months')
+    if delta.days != 0: result.append('days')
+    if delta.leapdays != 0: result.append('leapdays')
+    if delta.hours != 0: result.append('hours')
+    if delta.minutes != 0: result.append('minutes')
+    if delta.seconds != 0: result.append('seconds')
+    if delta.microseconds != 0: result.append('microseconds')
+    return result
+
+def _portionOfYearPeriodicMonthly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta(period)
+    if fieldsInPeriod != ['months'] and fieldsInPeriod != ['years', 'months']:
+        raise ArgumentError("Periodic monthly accrual model does not support periods " +
+                            "containing non-month, non-year values")
+    return period.years + period.months / 12
+
+def _portionOfYearPeriodicSemiMonthly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta
+    daysInMonth = monthrange(date.year, date.month)[1]
+    dateBeginningPeriod = date - period
+    daysInMonthBeginning = monthrange(dateBeginningPeriod.year,
+                                      dateBeginningPeriod.month)[1]
+
+    if (
+        fieldsInPeriod != ['days'] and fieldsInPeriod != ['months', 'days'] and \
+        fieldsInPeriod != ['years', 'months', 'days']
+    ):
+        raise ArgumentError("Periodic semi-monthly accrual model does not support " +
+                            "periods containing non-day, non-month, non-year values")
+    if date.day != 15 and date.day != daysInMonth:
+        raise ArgumentError("Periodic semi-monthly accrual model does not support " +
+                            "dates not on the 15th or final day of the month")
+    if dateBeginningPeriod != 15 and dateBeginningPeriod != daysInMonthBeginning:
+        raise ArgumentError("Periodic semi-monthly accrual model requires that the " +
+                            "date that would begin the period be on the 15th or " +
+                            "final day of the month")
+
+    periods = (date.year - dateBeginningPeriod.year) * 24
+    periods += (date.month - dateBeginningPeriod.month) * 2
+    if date.day == daysInMonth and dateBeginningPeriod.day == 15:
+        periods += 1
+    elif date.day == 15 and dateBeginningPeriod.day == daysInMonthBeginning:
+        periods -= 1
+    return periods / 24
+
+def _portionOfYearPeriodicWeekly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta(period)
+    if fieldsInPeriod != ['days']:
+        raise ArgumentError("Periodic weekly accrual model does not support periods " +
+                            "containing non-day values")
+    if period.days % 7:
+        raise ArgumentError("Periodic weekly accrual model only works for periods " +
+                            "that are multiples of 7 days")
+    return (period.days // 7) / 52
+
+def _portionOfYearPeriodicBiweekly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta(period)
+    if fieldsInPeriod != ['days']:
+        raise ArgumentError("Periodic biweekly accrual model does not support " +
+                            "periods containing non-day values")
+    if period.days % 14:
+        raise ArgumentError("Periodic weekly accrual model only works for periods " +
+                            "that are multiples of 14 days")
+    return (period.days // 14) / 26
+
+def _portionOfYearProRata(date: date, period: relativedelta):
+    periodStart = date - period
+    days = date.toordinal() - periodStart.toordinal()
+    daysInYear = 366 if isleap(date.year) else 365
+    return days / daysInYear
+
+def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel) -> float:
+    if accrualModel == AccrualModel.PeriodicMonthly:
+        return _portionOfYearPeriodicMonthly(date, period)
+    elif accrualModel == AccrualModel.PeriodicSemiMonthly:
+        return _portionOfYearPeriodicSemiMonthly(date, period)
+    elif accrualModel == AccrualModel.PeriodicWeekly:
+        return _portionOfYearPeriodicWeekly(date, period)
+    elif accrualModel == AccrualModel.PeriodicBiweekly:
+        return _portionOfYearPeriodicBiweekly(date, period)
+    else: # pro rata
+        return _portionOfYearProRata(date, period)
+

--- a/src/finance_sim/scheduling.py
+++ b/src/finance_sim/scheduling.py
@@ -10,6 +10,7 @@ class AccrualModel(Enum):
     PeriodicSemiMonthly = 2
     PeriodicWeekly = 3
     PeriodicBiweekly = 4
+    PeriodicYearly = 5
 
 def nonZeroValuesInDelta(delta: relativedelta) -> list[str]:
     result: list[str] = []
@@ -79,6 +80,13 @@ def _portionOfYearPeriodicBiweekly(date: date, period: relativedelta):
                             "that are multiples of 14 days")
     return (period.days // 14) / 26
 
+def _portionOfYearPeriodicYearly(date: date, period: relativedelta):
+    fieldsInPeriod = nonZeroValuesInDelta(period)
+    if fieldsInPeriod != ['years']:
+        raise ArgumentError("Periodic yearly accrual model does not support periods " +
+                            "containing non-year values")
+    return period.years
+
 def _portionOfYearProRata(date: date, period: relativedelta):
     periodStart = date - period
     days = date.toordinal() - periodStart.toordinal()
@@ -94,6 +102,8 @@ def portionOfYear(date: date, period: relativedelta, accrualModel: AccrualModel)
         return _portionOfYearPeriodicWeekly(date, period)
     elif accrualModel == AccrualModel.PeriodicBiweekly:
         return _portionOfYearPeriodicBiweekly(date, period)
+    elif accrualModel == AccrualModel.PeriodicYearly:
+        return _portionOfYearPeriodicYearly(date, period)
     else: # pro rata
         return _portionOfYearProRata(date, period)
 

--- a/test/amortizing-loan.py
+++ b/test/amortizing-loan.py
@@ -1,46 +1,56 @@
 import pytest
 from finance_sim import *
+from datetime import date
+from dateutil.relativedelta import relativedelta
 
 def testAmortizingLoanTerm():
     loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
-    state = FinanceState(100000)
+    state = FinanceState(date(1999, 12, 1))
+    state.cash = 100000
     history = FinanceHistory(state)
     state.amortizingLoans['test'] = loan
-    state = makeAmortizedPayments(history, state, 0, 1 / 12)
+    delta = relativedelta(months=1)
+    state = makeAmortizedPayments(history, state, date(2000, 1, 1), delta)
     assert state.amortizingLoans['test'].term == pytest.approx(20 - 1 / 12)
-    for i in range(1, 12):
-        state = makeAmortizedPayments(history, state, i, 1 / 12)
+    for month in range(2, 13):
+        state = makeAmortizedPayments(history, state, date(2000, month, 1), delta)
     assert state.amortizingLoans['test'].term == pytest.approx(19)
 
 def testAmortizingLoanFullPayment():
     loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
-    state = FinanceState(600000)
+    state = FinanceState(date(1999, 12, 1))
+    state.cash = 600000
     history = FinanceHistory(state)
     state.amortizingLoans['test'] = loan
     assert state.amortizingLoans['test'].principle == 0
-    for i in range(12 * 20):
-        state = makeAmortizedPayments(history, state, i, 1 / 12)
+    delta = relativedelta(months=1)
+    for year in range(2000,2020):
+        for month in range(1, 13):
+            state = makeAmortizedPayments(history, state, date(year, month, 1), delta)
     assert state.amortizingLoans['test'].principle == pytest.approx(100000)
 
 def testAmortizingLoanConstantPaymentCost():
     loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
-    state = FinanceState(600000)
+    state = FinanceState(date(1999, 12, 1))
+    state.cash = 600000
     history = FinanceHistory(state)
     state.amortizingLoans['test'] = loan
-    state = makeAmortizedPayments(history, state, 0, 1 / 12)
+    delta = relativedelta(months=1)
+    state = makeAmortizedPayments(history, state, date(2000, 1, 1), delta)
     previousCash = state.cash
     paymentAmount = 600000 - previousCash
-    for i in range(10):
-        state = makeAmortizedPayments(history, state, i, 1 / 12)
+    for month in range(2, 13):
+        state = makeAmortizedPayments(history, state, date(2000, month, 1), delta)
         assert previousCash - state.cash == pytest.approx(paymentAmount, 1e-3)
         previousCash = state.cash
 
 def testAmortizingLoanInterestRate():
     loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
-    state = FinanceState(600000)
+    state = FinanceState(date(2000, 1, 1))
+    state.cash = 600000
     history = FinanceHistory(state)
     state.amortizingLoans['test'] = loan
-    state = makeAmortizedPayments(history, state, 0, 1)
+    state = makeAmortizedPayments(history, state, date(2001, 1, 1), relativedelta(years=1))
     paymentAmount = 600000 - state.cash
     interestPayment = paymentAmount - state.amortizingLoans['test'].principle
     assert interestPayment == pytest.approx(100000 * 0.05, 1e-6)

--- a/test/amortizing-loan.py
+++ b/test/amortizing-loan.py
@@ -45,7 +45,7 @@ def testAmortizingLoanConstantPaymentCost():
         previousCash = state.cash
 
 def testAmortizingLoanInterestRate():
-    loan = AmortizingLoan('test', AccrualModel.ProRata, 0, 100000, 0.05, 20)
+    loan = AmortizingLoan('test', AccrualModel.PeriodicYearly, 0, 100000, 0.05, 20)
     state = FinanceState(date(2000, 1, 1))
     state.cash = 600000
     history = FinanceHistory(state)

--- a/test/amortizing-loan.py
+++ b/test/amortizing-loan.py
@@ -4,7 +4,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta
 
 def testAmortizingLoanTerm():
-    loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
+    loan = AmortizingLoan('test', AccrualModel.PeriodicMonthly, 0, 100000, 0.05, 20)
     state = FinanceState(date(1999, 12, 1))
     state.cash = 100000
     history = FinanceHistory(state)
@@ -17,7 +17,7 @@ def testAmortizingLoanTerm():
     assert state.amortizingLoans['test'].term == pytest.approx(19)
 
 def testAmortizingLoanFullPayment():
-    loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
+    loan = AmortizingLoan('test', AccrualModel.PeriodicMonthly, 0, 100000, 0.05, 20)
     state = FinanceState(date(1999, 12, 1))
     state.cash = 600000
     history = FinanceHistory(state)
@@ -30,7 +30,7 @@ def testAmortizingLoanFullPayment():
     assert state.amortizingLoans['test'].principle == pytest.approx(100000)
 
 def testAmortizingLoanConstantPaymentCost():
-    loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
+    loan = AmortizingLoan('test', AccrualModel.PeriodicMonthly, 0, 100000, 0.05, 20)
     state = FinanceState(date(1999, 12, 1))
     state.cash = 600000
     history = FinanceHistory(state)
@@ -45,7 +45,7 @@ def testAmortizingLoanConstantPaymentCost():
         previousCash = state.cash
 
 def testAmortizingLoanInterestRate():
-    loan = AmortizingLoan('test', 0, 100000, 0.05, 20)
+    loan = AmortizingLoan('test', AccrualModel.ProRata, 0, 100000, 0.05, 20)
     state = FinanceState(date(2000, 1, 1))
     state.cash = 600000
     history = FinanceHistory(state)

--- a/test/constant-expense.py
+++ b/test/constant-expense.py
@@ -1,30 +1,41 @@
 import pytest
 from finance_sim import *
+from datetime import date
+from dateutil.relativedelta import relativedelta
 
 
 def testExpenseMonthly():
-    financeData = FinanceHistory(FinanceState(10000))
-    financeData.setEventComponents([constantExpense(120)])
-    financeData.passEvent(1, 1 / 12)
-    financeData.passEvent(2, 1 / 12)
+    initialState = FinanceState(date(1999, 12, 1))
+    initialState.cash = 10000
+    financeData = FinanceHistory(initialState)
+    financeData.setEventComponents([constantExpense(120, AccrualModel.PeriodicMonthly)])
+    delta = relativedelta(months=1)
+    financeData.passEvent(date(2000, 1, 1), delta)
+    financeData.passEvent(date(2000, 2, 1), delta)
     assert financeData.data[0].cash == pytest.approx(10000)
     assert financeData.data[1].cash == pytest.approx(9990)
     assert financeData.data[2].cash == pytest.approx(9980)
 
 def testExpenseAnnual():
-    financeData = FinanceHistory(FinanceState(10000))
-    financeData.setEventComponents([constantExpense(120)])
-    financeData.passEvent(1, 1)
-    financeData.passEvent(2, 1)
+    initialState = FinanceState(date(2001, 1, 1))
+    initialState.cash = 10000
+    financeData = FinanceHistory(initialState)
+    financeData.setEventComponents([constantExpense(120, AccrualModel.ProRata)])
+    delta = relativedelta(years=1)
+    financeData.passEvent(date(2002, 1, 1), delta)
+    financeData.passEvent(date(2003, 1, 1), delta)
     assert financeData.data[0].cash == pytest.approx(10000)
     assert financeData.data[1].cash == pytest.approx(9880)
     assert financeData.data[2].cash == pytest.approx(9760)
 
 def testExpenseZero():
-    financeData = FinanceHistory(FinanceState(10000))
-    financeData.setEventComponents([constantExpense(0)])
-    financeData.passEvent(1, 1)
-    financeData.passEvent(2, 1)
+    initialState = FinanceState(date(2001, 1, 1))
+    initialState.cash = 10000
+    financeData = FinanceHistory(initialState)
+    financeData.setEventComponents([constantExpense(0, AccrualModel.ProRata)])
+    delta = relativedelta(years=1)
+    financeData.passEvent(date(2002, 1, 1), delta)
+    financeData.passEvent(date(2003, 1, 1), delta)
     assert financeData.data[0].cash == pytest.approx(10000)
     assert financeData.data[1].cash == pytest.approx(10000)
     assert financeData.data[2].cash == pytest.approx(10000)

--- a/test/constant-growth-asset.py
+++ b/test/constant-growth-asset.py
@@ -20,7 +20,7 @@ def testConstantGrowthMonthly():
 def testConstantGrowthAnnually():
     initialState = FinanceState(date(2001, 1, 1))
     initialState.constantGrowthAssets.append(
-        ConstantGrowthAsset(AccrualModel.ProRata, 100, 0.5))
+        ConstantGrowthAsset(AccrualModel.PeriodicYearly, 100, 0.5))
     financeData = FinanceHistory(initialState)
     financeData.setEventComponents([appreciateConstantAssets])
     delta = relativedelta(years=1)

--- a/test/constant-growth-asset.py
+++ b/test/constant-growth-asset.py
@@ -1,24 +1,31 @@
 import pytest
 from finance_sim import *
+from datetime import date
+from dateutil.relativedelta import relativedelta
 
 def testConstantGrowthMonthly():
-    initialState = FinanceState()
-    initialState.constantGrowthAssets.append(ConstantGrowthAsset(100, 0.5))
+    initialState = FinanceState(date(1999, 12, 1))
+    initialState.constantGrowthAssets.append(
+        ConstantGrowthAsset(AccrualModel.PeriodicMonthly, 100, 0.5))
     financeData = FinanceHistory(initialState)
     financeData.setEventComponents([appreciateConstantAssets])
     monthlyInterest = 1.5 ** (1 / 12)
-    for i in range(1, 10):
-        financeData.passEvent(i, 1 / 12)
-        assert financeData.data[i].constantGrowthAssets[0].value == \
-            pytest.approx(financeData.data[i-1].constantGrowthAssets[0].value * monthlyInterest)
+    delta = relativedelta(months=1)
+    for month in range(1, 10):
+        financeData.passEvent(date(2000, month, 1), delta)
+        assert financeData.data[month].constantGrowthAssets[0].value == \
+            pytest.approx(
+                financeData.data[month-1].constantGrowthAssets[0].value * monthlyInterest)
 
 def testConstantGrowthAnnually():
-    initialState = FinanceState()
-    initialState.constantGrowthAssets.append(ConstantGrowthAsset(100, 0.5))
+    initialState = FinanceState(date(2001, 1, 1))
+    initialState.constantGrowthAssets.append(
+        ConstantGrowthAsset(AccrualModel.ProRata, 100, 0.5))
     financeData = FinanceHistory(initialState)
     financeData.setEventComponents([appreciateConstantAssets])
-    for i in range(1, 10):
-        financeData.passEvent(i, 1)
-        assert financeData.data[i].constantGrowthAssets[0].value == \
-            pytest.approx(financeData.data[i-1].constantGrowthAssets[0].value * 1.5)
+    delta = relativedelta(years=1)
+    for year, idx in zip(range(2002, 2010), range(1, 9)):
+        financeData.passEvent(date(year, 1, 1), delta)
+        assert financeData.data[idx].constantGrowthAssets[0].value == \
+            pytest.approx(financeData.data[idx-1].constantGrowthAssets[0].value * 1.5)
 

--- a/test/constant-salaried-income.py
+++ b/test/constant-salaried-income.py
@@ -1,5 +1,6 @@
 import pytest
 from finance_sim import *
+from calendar import monthrange
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
@@ -11,42 +12,52 @@ def testSalariedIncomeMonthly():
     delta = relativedelta(months=1)
     for month in range(2, 100):
         financeData.passEvent(date(2000 + (month) // 12, ((month - 1) % 12) + 1, 1), delta)
-        newCash = financeData.data[idx].cash
+        newCash = financeData.latestEvent().cash
         assert newCash == pytest.approx(previousCash + 10)
         previousCash = newCash
     
 def testSalariedIncomeSemiMonthly():
-    financeData = FinanceHistory(FinanceState(date(2000, 1, 1)))
-    events: list[FinanceEvent] = [constantSalariedIncome(120, AccrualModel.ProRata)]
+    financeData = FinanceHistory(FinanceState(date(2000, 1, 15)))
+    events: list[FinanceEvent] = [constantSalariedIncome(120, AccrualModel.PeriodicSemiMonthly)]
     financeData.setEventComponents(events)
     previousCash = financeData.data[0].cash
     delta = relativedelta(months=1)
     for idx in range(1, 100):
-        month = idx // 2 + 1
-        day = 15 if month % 2 else 1
-        adjustedDate = date(2000 + (month // 12), month, day)
-        if month % 2:
-            delta = relativedelta(days=14)
+        month = (idx // 2) % 12 + 1
+        year = 2000 + (month // 12)
+        day = monthrange(year, month)[1] if idx % 2 else 15
+        adjustedDate = date(year, month, day)
+        if idx % 2:
+            delta = relativedelta(days = day - 15)
         else:
-            delta = relativedelta(days=(int(((date(2000 + (month // 12), month, 1) \
-                                              + relativedelta(months=1)) - adjustedDate)
-                                            .total_seconds()) // (24 * 3600)))
+            delta = relativedelta(days = 15)
         financeData.passEvent(adjustedDate, delta)
-        newCash = financeData.data[idx].cash
+        newCash = financeData.latestEvent().cash
         assert newCash == pytest.approx(previousCash + 5)
         previousCash = newCash
     
-def testSalariedIncomeBiAnnual():
+def testSalariedIncomeSemiAnnual():
     financeData = FinanceHistory(FinanceState(date(1999, 6, 1)))
-    events: list[FinanceEvent] = [constantSalariedIncome(100, AccrualModel.ProRata)]
+    events: list[FinanceEvent] = [constantSalariedIncome(100, AccrualModel.PeriodicMonthly)]
     financeData.setEventComponents(events)
     previousCash = financeData.data[0].cash
     for year in range(2000, 2006):
         for month in [1, 6]:
             financeData.passEvent(date(year, month, 1), relativedelta(months=6))
-            newCash = financeData.data[idx].cash
-            assert newCash == pytest.approx(previousCash + 200)
+            newCash = financeData.latestEvent().cash
+            assert newCash == pytest.approx(previousCash + 50)
             previousCash = newCash
+
+def testSalariedIncomeBiAnnual():
+    financeData = FinanceHistory(FinanceState(date(1999, 1, 1)))
+    events: list[FinanceEvent] = [constantSalariedIncome(100, AccrualModel.PeriodicYearly)]
+    financeData.setEventComponents(events)
+    previousCash = financeData.data[0].cash
+    for year in range(2000, 2009, 2):
+        financeData.passEvent(date(year, 1, 1), relativedelta(years=2))
+        newCash = financeData.latestEvent().cash
+        assert newCash == pytest.approx(previousCash + 200)
+        previousCash = newCash
 
 def testSalariedIncomeZero():
     financeData = FinanceHistory(FinanceState(date(1999, 12, 1)))
@@ -54,6 +65,6 @@ def testSalariedIncomeZero():
     financeData.setEventComponents(events)
     for month in range(1, 13):
         financeData.passEvent(date(2000, month, 1), relativedelta(months=1))
-        newCash = financeData.data[idx].cash
+        newCash = financeData.latestEvent().cash
         assert newCash == 0
 

--- a/test/constant-salaried-income.py
+++ b/test/constant-salaried-income.py
@@ -1,45 +1,59 @@
 import pytest
 from finance_sim import *
+from datetime import date
+from dateutil.relativedelta import relativedelta
 
 def testSalariedIncomeMonthly():
-    financeData = FinanceHistory(FinanceState(0))
-    events: list[FinanceEvent] = [constantSalariedIncome(120)]
+    financeData = FinanceHistory(FinanceState(date(2000, 1, 1)))
+    events = [constantSalariedIncome(120, AccrualModel.PeriodicMonthly)]
     financeData.setEventComponents(events)
     previousCash = financeData.data[0].cash
-    for idx in range(1, 100):
-        financeData.passEvent(idx, 1 / 12)
+    delta = relativedelta(months=1)
+    for month in range(2, 100):
+        financeData.passEvent(date(2000 + (month) // 12, ((month - 1) % 12) + 1, 1), delta)
         newCash = financeData.data[idx].cash
         assert newCash == pytest.approx(previousCash + 10)
         previousCash = newCash
     
-def testSalariedIncomeBiMonthly():
-    financeData = FinanceHistory(FinanceState(0))
-    events: list[FinanceEvent] = [constantSalariedIncome(120)]
+def testSalariedIncomeSemiMonthly():
+    financeData = FinanceHistory(FinanceState(date(2000, 1, 1)))
+    events: list[FinanceEvent] = [constantSalariedIncome(120, AccrualModel.ProRata)]
     financeData.setEventComponents(events)
     previousCash = financeData.data[0].cash
+    delta = relativedelta(months=1)
     for idx in range(1, 100):
-        financeData.passEvent(idx, 1 / 24)
+        month = idx // 2 + 1
+        day = 15 if month % 2 else 1
+        adjustedDate = date(2000 + (month // 12), month, day)
+        if month % 2:
+            delta = relativedelta(days=14)
+        else:
+            delta = relativedelta(days=(int(((date(2000 + (month // 12), month, 1) \
+                                              + relativedelta(months=1)) - adjustedDate)
+                                            .total_seconds()) // (24 * 3600)))
+        financeData.passEvent(adjustedDate, delta)
         newCash = financeData.data[idx].cash
         assert newCash == pytest.approx(previousCash + 5)
         previousCash = newCash
     
 def testSalariedIncomeBiAnnual():
-    financeData = FinanceHistory(FinanceState(0))
-    events: list[FinanceEvent] = [constantSalariedIncome(100)]
+    financeData = FinanceHistory(FinanceState(date(1999, 6, 1)))
+    events: list[FinanceEvent] = [constantSalariedIncome(100, AccrualModel.ProRata)]
     financeData.setEventComponents(events)
     previousCash = financeData.data[0].cash
-    for idx in range(1, 10):
-        financeData.passEvent(idx, 2)
-        newCash = financeData.data[idx].cash
-        assert newCash == pytest.approx(previousCash + 200)
-        previousCash = newCash
+    for year in range(2000, 2006):
+        for month in [1, 6]:
+            financeData.passEvent(date(year, month, 1), relativedelta(months=6))
+            newCash = financeData.data[idx].cash
+            assert newCash == pytest.approx(previousCash + 200)
+            previousCash = newCash
 
 def testSalariedIncomeZero():
-    financeData = FinanceHistory(FinanceState(0))
-    events: list[FinanceEvent] = [constantSalariedIncome(0)]
+    financeData = FinanceHistory(FinanceState(date(1999, 12, 1)))
+    events: list[FinanceEvent] = [constantSalariedIncome(0, AccrualModel.PeriodicMonthly)]
     financeData.setEventComponents(events)
-    for idx in range(1, 10):
-        financeData.passEvent(idx, 2)
+    for month in range(1, 13):
+        financeData.passEvent(date(2000, month, 1), relativedelta(months=1))
         newCash = financeData.data[idx].cash
         assert newCash == 0
 

--- a/test/taxes.py
+++ b/test/taxes.py
@@ -1,52 +1,69 @@
 import pytest
 from finance_sim import *
+from ctypes import ArgumentError
+from datetime import date
+from dateutil.relativedelta import relativedelta
 
 def testSalariedIncomeFlatTax():
-    history = FinanceHistory(FinanceState(0))
+    history = FinanceHistory(FinanceState(date(1999, 12, 1)))
+    delta = relativedelta(months=1)
     history.setEventComponents(
-        [constantSalariedIncome(100000),
-         taxPaymentSchedule(1 / 12, [TaxBracket(rate = 0.05, income = 0)])])
-    for i in range(12):
-        history.passEvent(i + 1, 1 / 12)
+        [constantSalariedIncome(100000, AccrualModel.PeriodicMonthly),
+         taxPaymentSchedule(delta,
+                            AccrualModel.PeriodicMonthly,
+                            [TaxBracket(rate = 0.05, income = 0)])])
+    for month in range(1, 13):
+        history.passEvent(date(2000, month, 1), delta)
     assert history.latestEvent().cash == pytest.approx(100000 * (1 - 0.05))
     assert history.latestEvent().taxableIncome == pytest.approx(0)
     assert history.latestEvent().taxesPaid == pytest.approx(5000)
 
 def testIsolatedTaxableIncome():
-    history = FinanceHistory(FinanceState(0))
+    history = FinanceHistory(FinanceState(date(1999, 1, 1)))
+    delta = relativedelta(years=1)
     history.setEventComponents(
-        [taxPaymentSchedule(1 / 12, [TaxBracket(rate = 0.05, income = 0)])])
+        [taxPaymentSchedule(delta,
+                            AccrualModel.PeriodicYearly,
+                            [TaxBracket(rate = 0.05, income = 0)])])
     history.latestEvent().taxableIncome = 100000
-    history.passEvent(1, 1)
+    history.passEvent(date(2000, 1, 1), delta)
     assert history.latestEvent().cash == pytest.approx(100000 * (- 0.05))
     assert history.latestEvent().taxableIncome == pytest.approx(0)
     assert history.latestEvent().taxesPaid == pytest.approx(5000)
 
 def testMultipleTaxBrackets():
-    history = FinanceHistory(FinanceState(0))
+    history = FinanceHistory(FinanceState(date(1999, 1, 1)))
+    delta = relativedelta(years=1)
     history.setEventComponents(
-        [taxPaymentSchedule(1 / 12,
+        [taxPaymentSchedule(delta,
+                            AccrualModel.PeriodicYearly,
                             [TaxBracket(rate = 0.05, income = 0),
                              TaxBracket(rate = 0.10, income = 40000),
                              TaxBracket(rate = 0.20, income = 60000)])])
     history.latestEvent().taxableIncome = 100000
-    history.passEvent(1, 1)
+    history.passEvent(date(2000, 1, 1), delta)
     expectedTaxPaid = 40000 * 0.05 + 20000 * 0.10 + 40000 * 0.20
     assert history.latestEvent().cash == pytest.approx(-expectedTaxPaid)
     assert history.latestEvent().taxableIncome == pytest.approx(0)
     assert history.latestEvent().taxesPaid == pytest.approx(expectedTaxPaid)
 
 def testMissingTaxBrackets():
-    with pytest.raises(RuntimeError):
-        history = FinanceHistory(FinanceState(0))
-        history.setEventComponents([taxPaymentSchedule(1 / 12, [])])
+    with pytest.raises(ArgumentError):
+        history = FinanceHistory(FinanceState(date(1999, 12, 1)))
+        delta = relativedelta(months=1)
+        history.setEventComponents([taxPaymentSchedule(delta,
+                                                       AccrualModel.PeriodicMonthly,
+                                                       [])])
         history.latestEvent().taxableIncome = 100000
-        history.passEvent(1, 1 / 12)
+        history.passEvent(date(2000, 1, 1), delta)
 
 def testNonZeroTaxBracket():
-    with pytest.raises(RuntimeError):
-        history = FinanceHistory(FinanceState(0))
+    with pytest.raises(ArgumentError):
+        history = FinanceHistory(FinanceState(date(1999, 12, 1)))
+        delta = relativedelta(months=1)
         history.setEventComponents(
-            [taxPaymentSchedule(1 / 12, [TaxBracket(rate = 0.05, income = 10)])])
+            [taxPaymentSchedule(delta,
+                                AccrualModel.PeriodicMonthly,
+                                [TaxBracket(rate = 0.05, income = 10)])])
         history.latestEvent().taxableIncome = 100000
-        history.passEvent(1, 1 / 12)
+        history.passEvent(date(2000, 1, 1), delta)


### PR DESCRIPTION
Previously, event periods were defined as a fraction of the year. E.g. `1 / 12` represents a month. That was just a placeholder for a more sophisticated scheduling system, which is included in this PR. Accrual for investments and finance events in general can now follow several periodic models, or pro rata, which is implemented as periodic daily.
